### PR TITLE
Typo in no_creds.md

### DIFF
--- a/excalimap/mindmap/ad/no_creds.md
+++ b/excalimap/mindmap/ad/no_creds.md
@@ -24,7 +24,7 @@
 - `smbclient -U '%' -L //<ip>`
 
 ## Enumerate LDAP >>> Username
-- `nmap -n -sV --script 'ldap*' and not brute -p 389 <dc_ip>`
+- `nmap -n -sV --script 'ldap* and not brute' -p 389 <dc_ip>`
 - `ldapsearch -x -H <dc_ip> -s base`
 
 ## Enumerate Users >>> Username


### PR DESCRIPTION
There is a small typo in the nmap command.