### PR TITLE
Add multiline text support across all elements

### DIFF
--- a/excalimap/main.py
+++ b/excalimap/main.py
@@ -38,6 +38,11 @@ def draw(matrix, main_title="", main_title_logo=""):
         "gridModeEnabled": False,
         "viewBackgroundColor": Config.background_color
     }
+
+    for el in elements:
+        if isinstance(el, dict) and "text" in el and isinstance(el["text"], str):
+            el["text"] = el["text"].replace("\\n", "\n")
+
     return json.dumps({"type": "excalidraw",
                            "version": 2,
                            "source": "https://excalidraw.com",

--- a/excalimap/main.py
+++ b/excalimap/main.py
@@ -39,16 +39,13 @@ def draw(matrix, main_title="", main_title_logo=""):
         "viewBackgroundColor": Config.background_color
     }
 
-    for el in elements:
-        if isinstance(el, dict) and "text" in el and isinstance(el["text"], str):
-            el["text"] = el["text"].replace("\\n", "\n")
-
-    return json.dumps({"type": "excalidraw",
+    json_output = json.dumps({"type": "excalidraw",
                            "version": 2,
                            "source": "https://excalidraw.com",
                            "elements": elements,
                            "appState": appstate,
                            "files": Utils.images_catalog}, indent=2)
+    return json_output.replace('\\\\n', '\\n')
 
 
 if __name__ == "__main__":

--- a/excalimap/main.py
+++ b/excalimap/main.py
@@ -9,6 +9,29 @@ from parsermd import ParserMD
 from utils import Utils
 from types import SimpleNamespace
 
+def fix_broken_container_ids(elements):
+    id_map = {el.get("id"): el for el in elements if isinstance(el, dict) and "id" in el}
+    MAX_DIST = 300
+
+    for el in elements:
+        if not isinstance(el, dict):
+            continue
+        cid = el.get("containerId")
+        if not cid:
+            continue
+
+        parent = id_map.get(cid)
+        if parent is None or parent.get("isDeleted") or parent.get("type") == "text":
+            el["containerId"] = None
+            continue
+
+        ex, ey = el.get("x"), el.get("y")
+        px, py = parent.get("x"), parent.get("y")
+        if all(isinstance(v, (int, float)) for v in (ex, ey, px, py)):
+            if abs(ex - px) > MAX_DIST or abs(ey - py) > MAX_DIST:
+                el["containerId"] = None
+
+
 def draw(matrix, main_title="", main_title_logo=""):
     elements = []
     x = end_x = 0
@@ -31,6 +54,8 @@ def draw(matrix, main_title="", main_title_logo=""):
             end_x = max(end_x, container_end_x)
             y = end_y + Config.space_height * 2 + Config.container_title_height
         x = end_x + Config.space_width * 2
+
+    fix_broken_container_ids(elements)
 
     appstate = {
         "gridSize": 20,

--- a/excalimap/mindmap/example/example.md
+++ b/excalimap/mindmap/example/example.md
@@ -24,3 +24,7 @@
 - Level1
   - `Level2`
     - Level3
+
+## Title line 1\nTitle line 2\nTitle line 3\nTitle line 4 >>> out box line 1\nout box line 2\nout box line 4\nout box line 4
+- Info line 1\nInfo line 2\nInfo line 3\nInfo line 4
+  - `Command line 1\nCommand line 2\nCommand line 3\nCommand line 4`

--- a/excalimap/models/command.py
+++ b/excalimap/models/command.py
@@ -1,4 +1,5 @@
 import math
+import re
 
 from config import Config
 from models.mapobject import MapObject
@@ -24,11 +25,11 @@ class Command(MapObject):
         text_padding = 5
         # end_x and end_y will be minimum to element size
 
-        lines = self.text.split("\n")
+        lines = re.split(r'(?<!\\)\n', self.text)
         longest_line = max(lines, key=lambda s: Utils.len_text(s))
         longest_len = Utils.len_text(longest_line)
 
-        calc_width = text_padding + Config.image_width + text_padding + math.ceil(longest_len * 8.75)
+        calc_width = text_padding + Config.image_width + text_padding + math.ceil(longest_len * 10)
         self.object_width = max(self.object_width, calc_width)
 
         line_count = self.text.count("\n") + 1

--- a/excalimap/models/command.py
+++ b/excalimap/models/command.py
@@ -24,16 +24,25 @@ class Command(MapObject):
         text_padding = 5
         # end_x and end_y will be minimum to element size
 
-        calc_width = text_padding + Config.image_width + text_padding + math.ceil(Utils.len_text(self.text) * 8.75)
+        lines = self.text.split("\\n")
+        longest_line = max(lines, key=lambda s: Utils.len_text(s))
+        longest_len = Utils.len_text(longest_line)
+
+        calc_width = text_padding + Config.image_width + text_padding + math.ceil(longest_len * 8.75)
         self.object_width = max(self.object_width, calc_width)
+
+        line_count = self.text.count("\\n") + 1
+        per_line = 25
+        dynamic_height = max(Config.command_height, line_count * per_line)
+
         end_x = x + self.object_width
-        end_y = y + Config.command_height
+        end_y = y + dynamic_height
 
         # draw all the content
         elements, end_x, end_y = self.draw_child(elements, x, y, end_x, end_y)
         total_size = end_y - y
         center_y = y + total_size / 2
-        title_y = center_y - Config.command_height / 2
+        title_y = center_y - dynamic_height / 2
 
         # draw out
         elements, out_end_x, out_end_y = self.draw_out(elements, y, center_y, total_size, end_x, end_y, Config.default_out_color)
@@ -81,7 +90,7 @@ class Command(MapObject):
                        "x": x,
                        "y": title_y,
                        "width": self.object_width,
-                       "height": Config.command_height,
+                       "height": dynamic_height,
                        "angle": 0,
                        "strokeColor": Config.border_color,
                        "backgroundColor": background_color,
@@ -108,7 +117,7 @@ class Command(MapObject):
                        "x": x + text_padding,
                        "y": title_y,
                        "width": self.object_width-5,
-                       "height": Config.command_height,
+                       "height": dynamic_height,
                        "angle": 0,
                        "strokeColor": text_color,
                        "backgroundColor": None,

--- a/excalimap/models/command.py
+++ b/excalimap/models/command.py
@@ -24,14 +24,14 @@ class Command(MapObject):
         text_padding = 5
         # end_x and end_y will be minimum to element size
 
-        lines = self.text.split("\\n")
+        lines = self.text.split("\n")
         longest_line = max(lines, key=lambda s: Utils.len_text(s))
         longest_len = Utils.len_text(longest_line)
 
         calc_width = text_padding + Config.image_width + text_padding + math.ceil(longest_len * 8.75)
         self.object_width = max(self.object_width, calc_width)
 
-        line_count = self.text.count("\\n") + 1
+        line_count = self.text.count("\n") + 1
         per_line = 25
         dynamic_height = max(Config.command_height, line_count * per_line)
 

--- a/excalimap/models/info.py
+++ b/excalimap/models/info.py
@@ -1,4 +1,5 @@
 import math
+import re
 
 from config import Config
 from models.arrow import Arrow
@@ -20,7 +21,7 @@ class Info(MapObject):
     def draw(self, x, y):
         elements = []
 
-        lines = self.text.split("\n")
+        lines = re.split(r'(?<!\\)\n', self.text)
         longest_line = max(lines, key=lambda s: Utils.len_text(s))
         longest_len = Utils.len_text(longest_line)
 

--- a/excalimap/models/info.py
+++ b/excalimap/models/info.py
@@ -19,18 +19,27 @@ class Info(MapObject):
 
     def draw(self, x, y):
         elements = []
+
+        lines = self.text.split("\\n")
+        longest_line = max(lines, key=lambda s: Utils.len_text(s))
+        longest_len = Utils.len_text(longest_line)
+
         # end_x and end_y will be minimum to title draw size
-        calc_width = math.ceil(Utils.len_text(self.text) * 10)
+        calc_width = math.ceil(longest_len * 10)
         self.object_width = max(calc_width,self.object_width)
 
+        line_count = self.text.count("\\n") + 1
+        per_line = 25
+        dynamic_height = max(Config.info_height, line_count * per_line)
+
         end_x = x + self.object_width
-        end_y = y + Config.info_height
+        end_y = y + dynamic_height
 
         # draw all the content
         elements, end_x, end_y = self.draw_child(elements, x, y, end_x, end_y)
         total_size = end_y - y
         center_y = y + total_size / 2
-        title_y = center_y - Config.info_height / 2
+        title_y = center_y - dynamic_height / 2
         # draw out
         elements, end_x, end_y = self.draw_out(elements, y, center_y, total_size, end_x, end_y, Config.default_out_color)
 
@@ -46,7 +55,7 @@ class Info(MapObject):
                        "x": x,
                        "y": title_y,
                        "width": self.object_width,
-                       "height": Config.info_height,
+                       "height": dynamic_height,
                        "angle": 0,
                        "strokeColor": Config.border_color,
                        "backgroundColor": background_color,
@@ -73,7 +82,7 @@ class Info(MapObject):
                        "x": x + 5,
                        "y": title_y,
                        "width": self.object_width-5,
-                       "height": Config.info_height,
+                       "height": dynamic_height,
                        "angle": 0,
                        "strokeColor": text_color,
                        "backgroundColor": None,

--- a/excalimap/models/info.py
+++ b/excalimap/models/info.py
@@ -20,7 +20,7 @@ class Info(MapObject):
     def draw(self, x, y):
         elements = []
 
-        lines = self.text.split("\\n")
+        lines = self.text.split("\n")
         longest_line = max(lines, key=lambda s: Utils.len_text(s))
         longest_len = Utils.len_text(longest_line)
 
@@ -28,7 +28,7 @@ class Info(MapObject):
         calc_width = math.ceil(longest_len * 10)
         self.object_width = max(calc_width,self.object_width)
 
-        line_count = self.text.count("\\n") + 1
+        line_count = self.text.count("\n") + 1
         per_line = 25
         dynamic_height = max(Config.info_height, line_count * per_line)
 

--- a/excalimap/models/out.py
+++ b/excalimap/models/out.py
@@ -83,8 +83,13 @@ class Out(MapObject):
         return element, end_x, end_y
 
     def draw_out_element(self, x, y, color):
+        lines = self.text.split("\n")
+        per_line = 25
+        dynamic_height = max(Config.out_height, len(lines) * per_line)
+        y = y + (Config.out_height - dynamic_height) / 2
+
         end_x = x + Config.out_width
-        end_y = y + Config.out_height
+        end_y = y + dynamic_height
 
         elements = []
 
@@ -106,7 +111,7 @@ class Out(MapObject):
             "x": x,
             "y": y,
             "width": Config.out_width,
-            "height": Config.out_height,
+            "height": dynamic_height,
             "angle": 0,
             "strokeColor": "#1e1e1e",
             "backgroundColor": self.color,
@@ -132,7 +137,7 @@ class Out(MapObject):
                 "x": x + 5,
                 "y": y,
                 "width": Config.out_width - 5,
-                "height": Config.out_height,
+                "height": dynamic_height,
                 "angle": 0,
                 "strokeColor": Config.out_text_color,
                 "backgroundColor": None,

--- a/excalimap/models/out.py
+++ b/excalimap/models/out.py
@@ -1,3 +1,5 @@
+import re
+
 from config import Config
 from models.mapobject import MapObject
 from utils import Utils
@@ -83,7 +85,7 @@ class Out(MapObject):
         return element, end_x, end_y
 
     def draw_out_element(self, x, y, color):
-        lines = self.text.split("\n")
+        lines = re.split(r'(?<!\\)\n', self.text)
         per_line = 25
         dynamic_height = max(Config.out_height, len(lines) * per_line)
         y = y + (Config.out_height - dynamic_height) / 2

--- a/excalimap/models/title.py
+++ b/excalimap/models/title.py
@@ -15,15 +15,20 @@ class Title(MapObject):
 
     def draw(self, x, y, color):
         elements = []
+
+        line_count = self.text.count("\n") + 1
+        per_line = 25
+        dynamic_height = max(Config.title_height, line_count * per_line)
+
         # end_x and end_y will be minimum to title draw size
         end_x = x + Config.title_width
-        end_y = y + Config.title_height
+        end_y = y + dynamic_height
 
         # draw all the content
         elements, end_x, end_y = self.draw_child(elements, x, y, end_x, end_y)
         total_size = end_y - y
         center_y = y + total_size / 2
-        title_y = center_y - Config.title_height / 2
+        title_y = center_y - dynamic_height / 2
 
         # draw out
         elements, end_x, end_y = self.draw_out(elements, y, center_y, total_size, end_x, end_y, color)
@@ -35,7 +40,7 @@ class Title(MapObject):
                 "x": x,
                 "y": title_y,
                 "width": Config.title_width,
-                "height": Config.title_height,
+                "height": dynamic_height,
                 "angle": 0,
                 "strokeColor": Config.border_color,
                 "backgroundColor": color,
@@ -61,7 +66,7 @@ class Title(MapObject):
                 "x": x,
                 "y": title_y,
                 "width": Config.title_width,
-                "height": Config.title_height,
+                "height": dynamic_height,
                 "angle": 0,
                 "strokeColor": Config.title_text_color,
                 "backgroundColor": "transparent",

--- a/excalimap/models/title.py
+++ b/excalimap/models/title.py
@@ -1,3 +1,5 @@
+import math
+
 from config import Config
 from models.mapobject import MapObject
 from models.command import Command
@@ -16,12 +18,19 @@ class Title(MapObject):
     def draw(self, x, y, color):
         elements = []
 
+        lines = self.text.split("\n")
+        longest_line = max(lines, key=lambda s: Utils.len_text(s))
+        longest_len = Utils.len_text(longest_line)
+
+        calc_width = math.ceil(longest_len * 10)
+        self.object_width = max(self.object_width, calc_width)
+
         line_count = self.text.count("\n") + 1
         per_line = 25
         dynamic_height = max(Config.title_height, line_count * per_line)
 
         # end_x and end_y will be minimum to title draw size
-        end_x = x + Config.title_width
+        end_x = x + self.object_width
         end_y = y + dynamic_height
 
         # draw all the content
@@ -39,7 +48,7 @@ class Title(MapObject):
                 "id": f"{self.object_id}",
                 "x": x,
                 "y": title_y,
-                "width": Config.title_width,
+                "width": self.object_width,
                 "height": dynamic_height,
                 "angle": 0,
                 "strokeColor": Config.border_color,
@@ -65,7 +74,7 @@ class Title(MapObject):
                 "id": f"{self.object_id + hash(self.text)}",
                 "x": x,
                 "y": title_y,
-                "width": Config.title_width,
+                "width": self.object_width,
                 "height": dynamic_height,
                 "angle": 0,
                 "strokeColor": Config.title_text_color,

--- a/excalimap/models/title.py
+++ b/excalimap/models/title.py
@@ -1,4 +1,5 @@
 import math
+import re
 
 from config import Config
 from models.mapobject import MapObject
@@ -18,11 +19,11 @@ class Title(MapObject):
     def draw(self, x, y, color):
         elements = []
 
-        lines = self.text.split("\n")
+        lines = re.split(r'(?<!\\)\n', self.text)
         longest_line = max(lines, key=lambda s: Utils.len_text(s))
         longest_len = Utils.len_text(longest_line)
 
-        calc_width = math.ceil(longest_len * 10)
+        calc_width = math.ceil(longest_len * 10 + 30)
         self.object_width = max(self.object_width, calc_width)
 
         line_count = self.text.count("\n") + 1

--- a/excalimap/parsermd.py
+++ b/excalimap/parsermd.py
@@ -99,7 +99,7 @@ class ParserMD:
                                 out[0].out[-1].out = [new_out]
                         id_out += 1
                     column += 1
-                line = line.split('>>>')[0]
+                line = line.split('>>>')[0].rstrip()
 
             if "@CVE@" in line:
                 cve = True

--- a/excalimap/requirements.txt
+++ b/excalimap/requirements.txt
@@ -1,2 +1,3 @@
 pyyaml
 pillow
+wcwidth

--- a/excalimap/utils.py
+++ b/excalimap/utils.py
@@ -47,15 +47,22 @@ class Utils:
 
     @staticmethod
     def split_text(text, size_newline):
-        if len(text) > size_newline:
-            middle_text = len(text) / 2
-            text_blocs = text.split(' ')
-            text_multiline = ''
-            split = False
-            for text_bloc in text_blocs:
-                if len(text_multiline) > middle_text and not split:
-                    text_multiline += '\n'
-                    split = True
-                text_multiline += text_bloc + ' '
-            text = text_multiline.strip()
-        return text
+        raw_lines = text.replace('\\n', '\n').split('\n')
+
+        processed_lines = []
+        for line in raw_lines:
+            if len(line) > size_newline:
+                middle_text = len(line) / 2
+                text_blocs = line.split(' ')
+                text_multiline = ''
+                split = False
+                for text_bloc in text_blocs:
+                    if len(text_multiline) > middle_text and not split:
+                        text_multiline += '\n'
+                        split = True
+                    text_multiline += text_bloc + ' '
+                processed_lines.append(text_multiline.strip())
+            else:
+                processed_lines.append(line)
+
+        return '\n'.join(processed_lines)

--- a/excalimap/utils.py
+++ b/excalimap/utils.py
@@ -1,3 +1,5 @@
+from wcwidth import wcwidth
+
 class Utils:
 
     images_catalog = {}
@@ -42,7 +44,7 @@ class Utils:
     def len_text(text):
         size = 0
         for txt in text.split('\n'):
-            size = max(len(txt), size)
+            size = max(sum(max(wcwidth(ch), 1) for ch in txt), size)
         return size
 
     @staticmethod


### PR DESCRIPTION
Added multiline text support to all elements (`Title`, `Info`, `Command`, and `Out`).
Each element now adjusts its height dynamically based on line count, ensuring proper alignment and consistent layout in Excalidraw output.